### PR TITLE
Try TMPDIR, TMP, TEMP environment variables first

### DIFF
--- a/configure
+++ b/configure
@@ -25,13 +25,15 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [ $(command -v brew) ]; then
     BREWDIR=$(brew --prefix)
   else
-    BREWDIR="/tmp/homebrew"
-    rm -Rf $BREWDIR
+    TEMP_DIR=${TMPDIR-${TMP-${TEMP-/tmp}}}
+    BREWDIR=$TEMP_DIR/homebrew
+    rm -Rf "$BREWDIR"
+    BREWCACHE=$TEMP_DIR
     mkdir -p $BREWDIR
     echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
     curl -fsSL https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
     $BREWDIR/bin/brew tap homebrew/versions 2>&1 | perl -pe 's/Warning/Note/gi'
-    HOMEBREW_CACHE="/tmp" $BREWDIR/bin/brew install $PKG_BREW_NAME --force-bottle 2>&1 | perl -pe 's/Warning/Note/gi'
+    HOMEBREW_CACHE="$BREWCACHE" $BREWDIR/bin/brew install $PKG_BREW_NAME --force-bottle 2>&1 | perl -pe 's/Warning/Note/gi'
     rm -f $BREWDIR/opt/$PKG_BREW_NAME/lib/*.dylib
     PKG_LIBS="$PKG_LIBS_STATIC"
   fi


### PR DESCRIPTION
Before falling back to /tmp.

Not all systems have a writable `/tmp`, in particular the MacOS workers for R-hub do not.

This sets the temp directory to first of `TMPDIR`, `TMP`, `TEMP`, which is the [same logic used by R](https://github.com/wch/r-source/blob/b00a84f5bc542838184fdd55edf4cf23ddc4fa02/src/main/sysutils.c#L1562-L1572).