### PR TITLE
temporal V8_VERSION_TOTAL cleanup

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -100,7 +100,7 @@ static v8::MaybeLocal<v8::Module> ResolveModuleCallback(v8::Local<v8::Context> c
     isolate->ThrowException(ToJSString(err.what()));
   }
   return v8::Local<v8::Module>();
-};
+}
 
 static v8::MaybeLocal<v8::Promise> dynamic_module_loader(v8::Local<v8::Context> context, v8::Local<v8::String> specifier) {
   v8::Local<v8::Promise::Resolver> resolver = v8::Promise::Resolver::New(context).ToLocalChecked();
@@ -201,7 +201,7 @@ void start_v8_isolate(void *dll){
   platformptr = v8::platform::CreateDefaultPlatform();
   v8::V8::InitializePlatform(platformptr);
 #endif
-#if V8_VERSION_TOTAL >= 1401
+#if V8_VERSION_TOTAL >= 1401 && V8_VERSION_TOTAL < 1404
   v8::V8::SetFlagsFromString("--harmony-temporal");
 #endif
 #if V8_VERSION_TOTAL > 805 && V8_VERSION_TOTAL < 909


### PR DESCRIPTION
temporal no longer requires the harmony flag https://chromium.googlesource.com/v8/v8.git/+/50b71a5eab90f60b4fc14a4cca0bb81f95a46ff7

~~I've removed a few additional V8_VERSION_TOTAL defines, so that bindings.cpp now targets at least 9.1 which was [branched of ~4 1/2 years ago](https://chromium.googlesource.com/v8/v8.git/+log/branch-heads/9.1) and is the oldest in the [winlibs.R](https://github.com/jeroen/V8/blob/master/tools/winlibs.R) file~~
V8 still requires support for older V8 releases.